### PR TITLE
chore: Update MCP Atlassian configuration to use official SSE endpoint

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,0 @@
-# Database Configuration
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/team_spark_dev
-
-# Atlassian API Configuration
-JIRA_URL=https://d-stats.atlassian.net
-JIRA_USERNAME=your-email@example.com
-JIRA_API_TOKEN=your-jira-api-token

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,8 @@
 {
   "mcpServers": {
-    "mcp-atlassian": {
-      "command": "uvx",
-      "args": ["mcp-atlassian"],
-      "env": {}
+    "atlassian": {
+      "type": "sse",
+      "url": "https://mcp.atlassian.com/v1/sse"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -665,7 +665,22 @@ import { serverFormatDate, serverFormatNumber } from '@/lib/i18n-server';
 
 ## 🔧 MCP Atlassian Integration
 
-TeamSpark AI uses the [D-Stats organization MCP setup](../CLAUDE.md#mcp-model-context-protocol-integration). Project-specific configuration:
+TeamSpark AI uses the official Atlassian MCP server via SSE. Configuration is set up in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "atlassian": {
+      "type": "sse",
+      "url": "https://mcp.atlassian.com/v1/sse"
+    }
+  }
+}
+```
+
+For detailed setup instructions, see [Setup Guide](./docs/guides/setup.md#5-mcp-atlassian-setup-optional).
+
+### Project-specific configuration:
 
 ### JIRA Project Details
 
@@ -692,7 +707,7 @@ fix(TSA-456): Resolve Slack integration timeout
 - **Slack Integration**: Include Slack channel mentions in task descriptions
 - **i18n Tasks**: Tag with "i18n" label for internationalization work
 
-Refer to [D-Stats MCP Integration](../CLAUDE.md#mcp-model-context-protocol-integration) for detailed JIRA setup and commands.
+For additional JIRA workflow patterns, refer to [D-Stats MCP Integration](../CLAUDE.md#mcp-model-context-protocol-integration).
 
 ## 🚫 ESLint Compliance
 

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -69,9 +69,6 @@ Create `.env` file from examples:
 ```bash
 # Copy main environment variables
 cp .env.example .env
-
-# If using MCP Atlassian integration, append those variables
-cat .env.sample >> .env
 ```
 
 ### 3.3 Configure Environment Variables
@@ -150,28 +147,34 @@ npm run prisma:studio
 
 ## 5. MCP Atlassian Setup (Optional)
 
-If you're using JIRA integration:
+If you're using JIRA integration with Claude Code:
 
-### 5.1 Install MCP Atlassian
+### 5.1 Configure MCP Server
 
-```bash
-# Install using uv (Python package manager)
-uv tool install mcp-atlassian
+The project is configured to use the official Atlassian MCP server via SSE. The configuration is already set up in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "atlassian": {
+      "type": "sse",
+      "url": "https://mcp.atlassian.com/v1/sse"
+    }
+  }
+}
 ```
 
-### 5.2 Configure JIRA Credentials
+### 5.2 Authentication
 
-Add to your `.env` file:
+When using Claude Code, you'll be prompted to authenticate with Atlassian when first accessing JIRA features. No additional local installation or API tokens are required.
 
-```bash
-JIRA_URL=https://your-company.atlassian.net
-JIRA_USERNAME=your-email@example.com
-JIRA_API_TOKEN=your-jira-api-token
-```
+### 5.3 Project Configuration
 
-### 5.3 Restart Claude Code
+This project is configured for:
 
-After configuration, restart Claude Code to load the MCP server.
+- **Project Key**: TSA
+- **Issue Types**: Task, Bug, Story
+- **Epic Pattern**: Use "Epic: [Name]" prefix for parent tasks
 
 ## 6. Create Slack App (Optional)
 

--- a/docs/setup/ENVIRONMENT_SETUP.md
+++ b/docs/setup/ENVIRONMENT_SETUP.md
@@ -9,8 +9,8 @@ TeamSpark AI uses multiple environment files for different purposes:
 ```
 .env                  # Main environment file (git ignored)
 .env.example          # Example for TeamSpark AI variables
-.env.sample           # Example for MCP Atlassian variables
 .envrc                # direnv configuration
+.mcp.json             # MCP server configuration
 ```
 
 ## 🔧 direnv Setup
@@ -101,9 +101,6 @@ This automatically loads all variables from `.env` when you enter the project di
 ```bash
 # Copy from example files
 cp .env.example .env
-
-# If using MCP Atlassian integration
-cat .env.sample >> .env
 ```
 
 ### 2. Core Application Variables
@@ -158,15 +155,20 @@ SMTP_SECURE=false
 
 #### MCP Atlassian Integration (Optional)
 
-```bash
-# JIRA Configuration
-JIRA_URL=https://your-company.atlassian.net
-JIRA_USERNAME=your-email@example.com
-JIRA_API_TOKEN=your-jira-api-token
+MCP (Model Context Protocol) Atlassian integration is configured via `.mcp.json` for Claude Code users. The configuration uses the official Atlassian SSE endpoint:
 
-# Optional: Filter specific projects
-JIRA_PROJECTS_FILTER=TSA,PROJ2
+```json
+{
+  "mcpServers": {
+    "atlassian": {
+      "type": "sse",
+      "url": "https://mcp.atlassian.com/v1/sse"
+    }
+  }
+}
 ```
+
+**Note**: No additional environment variables or API tokens are required. Authentication is handled directly through Claude Code when accessing JIRA features.
 
 ### 3. Environment-Specific Configurations
 
@@ -242,7 +244,7 @@ SESSION_SECRET=yet-another-secure-random-string
 - [ ] Set application URL
 - [ ] (Optional) Add Slack credentials
 - [ ] (Optional) Configure email service
-- [ ] (Optional) Add JIRA credentials for MCP
+- [ ] (Optional) Verify MCP Atlassian configuration in `.mcp.json`
 - [ ] Run `direnv allow .` in project directory
 - [ ] Verify with `npm run pre-flight`
 


### PR DESCRIPTION
## Summary

- Remove obsolete .env.sample file with JIRA credentials
- Update documentation to reflect new SSE-based MCP Atlassian configuration
- Simplify MCP setup process (no local installation required)
- Update all guides to use official Atlassian MCP server

## Changes

### Files Modified
- `CLAUDE.md` - Updated MCP integration section with current SSE configuration
- `docs/guides/setup.md` - Replaced uv tool installation with SSE setup instructions
- `docs/setup/ENVIRONMENT_SETUP.md` - Updated environment files overview and MCP section

### Files Removed
- `.env.sample` - No longer needed as JIRA credentials are not required

## Benefits

- **Simplified Setup**: No need for local MCP server installation
- **Better Security**: No API tokens stored in environment files
- **Official Support**: Uses the official Atlassian MCP endpoint
- **Easier Maintenance**: Automatic updates through official endpoint

## Test Plan

- [x] TypeScript compilation passes
- [x] ESLint checks pass
- [x] Documentation links are valid
- [x] Verify MCP Atlassian integration works with Claude Code
- [x] Test JIRA operations through new SSE endpoint

🤖 Generated with [Claude Code](https://claude.ai/code)